### PR TITLE
Fix(Text Formatting): Remove indentation of first paragraph

### DIFF
--- a/FEIstyle.cls
+++ b/FEIstyle.cls
@@ -227,9 +227,9 @@
 \subsectionfont{\bf\fontsize{16pt}{1.3}\selectfont}
 \subsubsectionfont{\bf\fontsize{14pt}{1.3}\selectfont}
 
-\titlespacing\section{0pt}{24pt}{12pt}
-\titlespacing\subsection{6pt}{12pt}{6pt}
-\titlespacing\subsubsection{12pt}{10pt}{0pt}
+\titlespacing*\section{0pt}{24pt}{12pt}
+\titlespacing*\subsection{6pt}{12pt}{6pt}
+\titlespacing*\subsubsection{12pt}{10pt}{0pt}
 
 \lstset{
   basicstyle=\scriptsize\ttfamily,


### PR DESCRIPTION
The first paragraph of `\[...]section` has an indentation as the other paragraphs.
This is a non standard behaviour. Package `titlesec` tells about `\titlespacing`
command:
"The starred version kills the indentation of the paragraph following the title..."
So the fix adds the star to `\titlespacing` commands used in FEIstyle.cls file.